### PR TITLE
Add definitions for the type `AR_TYPE_SETTINGS`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+# This is a basic worflow which is meant to be a boilerplate for another one if it is ever needed.
+# It at least checks if the code compiles so the repository is not broken on pushes.
+
+name: CI
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repo
+      - uses: actions/checkout@v4
+
+        # Build the repo
+      - name: Build
+        run: |
+          make

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ LIB_OBJ= \
 	pattern.o \
 	kit.o \
 	sound.o \
+	settings.o \
 	global.o \
-	sysex.o
+	sysex.o 
 
 OBJ= \
 	$(LIB_OBJ) \

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-libanalogrytm
-=============
+# libanalogrytm
+
+[![Build Status](https://github.com/bsp2/libanalogrytm/workflows/CI/badge.svg)](https://github.com/bsp2/libanalogrytm/actions?query=workflow%3ACI)
 
 Portable Sysex Library for the Elektron Analog Rytm Drum Computer
-
 
 ## Introduction
 
@@ -11,7 +11,6 @@ decode, modify, and encode system exclusive messages sent/received by the Analog
 
 By design, the library itself does _NOT_ contain any actual MIDI I/O or user interface code.
 
-
 ## Legal
 
 This is not an official Elektron development.
@@ -19,7 +18,6 @@ This is not an official Elektron development.
 All file format information has been found out by analyzing/comparing hundreds of sysex messages sent by the AR.
 
 This library may be used in both open and closed source software (see [LICENSE](../master/LICENSE)).
-
 
 ## Status
 
@@ -30,6 +28,10 @@ This library may be used in both open and closed source software (see [LICENSE](
 - Most of the pattern format has been analyzed. See [pattern.h](../master/pattern.h).
 
 - Most of the kit format has been analyzed. See [kit.h](../master/kit.h).
+
+- Most of the global format has been analyzed. See [global.h](../master/global.h).
+
+- Most of the settings format has been analyzed. See [settings.h](../master/settings.h).
 
 - The library can convert a "whole project" .syx file (sent by the AR) to raw data, and back to .syx again.
   See [testcases/main.c](../master/testcases/main.c). Example output: [log.txt](../master/vs2013/libanalogrytm_test/Debug/log.txt).

--- a/error.h
+++ b/error.h
@@ -34,30 +34,30 @@
 
 #include "cplusplus_begin.h"
 
-
 /* library error codes */
-typedef enum {
-   AR_ERR_OK                      =  0,
+typedef enum
+{
+   AR_ERR_OK = 0,
 
-   AR_ERR_NOT_A_SYSEX_MSG         =  1,
-   AR_ERR_SHORT_READ              =  2,  /* srcbuffer too small */
-   AR_ERR_END_OF_MSG              =  3,  /* found 0xF7 terminator */
-   AR_ERR_ABORT                   =  4,  /* premature end of sysex message */
-   AR_ERR_INVALID_MANUFACTURER_ID =  5,  /* wrong manufacturer id */
-   AR_ERR_INVALID_PRODUCT_ID      =  6,  /* wrong product id */
-   AR_ERR_INVALID_DUMP_MSG_ID     =  7,  /* invalid dump message id */
-   AR_ERR_INVALID_OBJ_TYPE        =  8,  /* invalid object type */
-   AR_ERR_CHKSUM                  =  9,  /* checksum error */
-   AR_ERR_NULLPTR                 = 10,  /* unexpected NULL pointer */
-   AR_ERR_INVALID_OBJ_NR          = 11,  /* invalid object number (out of range) */
-   AR_ERR_NOT_A_PATTERN           = 12,  /* trying to convert syx that does not contain pattern data */
-   AR_ERR_NOT_A_KIT               = 13,  /* trying to convert syx that does not contain kit data */
-   AR_ERR_NOT_A_SOUND             = 14,  /* trying to convert syx that does not contain sound data */
-   AR_ERR_NOT_A_GLOBAL            = 15,  /* trying to convert syx that does not contain global data */
+   AR_ERR_NOT_A_SYSEX_MSG = 1,
+   AR_ERR_SHORT_READ = 2,              /* srcbuffer too small */
+   AR_ERR_END_OF_MSG = 3,              /* found 0xF7 terminator */
+   AR_ERR_ABORT = 4,                   /* premature end of sysex message */
+   AR_ERR_INVALID_MANUFACTURER_ID = 5, /* wrong manufacturer id */
+   AR_ERR_INVALID_PRODUCT_ID = 6,      /* wrong product id */
+   AR_ERR_INVALID_DUMP_MSG_ID = 7,     /* invalid dump message id */
+   AR_ERR_INVALID_OBJ_TYPE = 8,        /* invalid object type */
+   AR_ERR_CHKSUM = 9,                  /* checksum error */
+   AR_ERR_NULLPTR = 10,                /* unexpected NULL pointer */
+   AR_ERR_INVALID_OBJ_NR = 11,         /* invalid object number (out of range) */
+   AR_ERR_NOT_A_PATTERN = 12,          /* trying to convert syx that does not contain pattern data */
+   AR_ERR_NOT_A_KIT = 13,              /* trying to convert syx that does not contain kit data */
+   AR_ERR_NOT_A_SOUND = 14,            /* trying to convert syx that does not contain sound data */
+   AR_ERR_NOT_A_SETTINGS = 15,         /* trying to convert syx that does not contain settings data */
+   AR_ERR_NOT_A_GLOBAL = 16,           /* trying to convert syx that does not contain global data */
 
    NUM_AR_ERROR_CODES
 } ar_error_t;
-
 
 #include "cplusplus_end.h"
 

--- a/global.h
+++ b/global.h
@@ -45,14 +45,14 @@
  *
  */
 typedef struct {
-   sU8 version[4]; /* @0x00..0x04  32 bit version number (0x00, 0x00, 0x00, 0x02) */
+   sU8 version[4]; /* @0x00..0x03  32 bit version number (0x00, 0x00, 0x00, 0x02) */
 
    /* Click Menu */
-   sU8 click_active;       /* @0x05 0=OFF, 1=ON */
-   sU8 click_time_sig_num; /* @0x06 range=0..15 maps to 1..16 on device */
-   sU8 click_time_sig_den; /* @0x07 0=1, 1=2, 2=4, 3=8, 4=16 */
-   sU8 pre_roll;           /* @0x08 0=OFF, range=0..15 maps to 1..16 on device */
-   sU8 volume;             /* @0x09 range=0..127 */
+   sU8 click_active;       /* @0x04 0=OFF, 1=ON */
+   sU8 click_time_sig_num; /* @0x05 range=0..15 maps to 1..16 on device */
+   sU8 click_time_sig_den; /* @0x06 0=1, 1=2, 2=4, 3=8, 4=16 */
+   sU8 pre_roll;           /* @0x07 0=OFF, range=0..15 maps to 1..16 on device */
+   sU8 volume;             /* @0x08 range=0..127 */
 
    /* Currently reads  0x40, 0x00 */
    sU8 __unknown0x09_0x0A[2]; /* @?0x09..0x0A */
@@ -107,7 +107,7 @@ typedef struct {
    sU8 send_to_fx_lsb;    /* @?0x35 */
 
    /* All zeros. It is suspicious since it is exactly 16 bytes long, maybe related to midi channels? */
-   sU8 __unknown0x36_0x45[16]; /* @?0x04..0x45 */
+   sU8 __unknown0x36_0x45[16]; /* @?0x36..0x45 */
 
    /* Sequencer Config Menu Part 2 */
    sU8 auto_trk_switch; /* @0x46 0=OFF, 1=ON */

--- a/inc_ar.h
+++ b/inc_ar.h
@@ -23,7 +23,7 @@
  * ----
  * ---- info   : This is part of the "libanalogrytm" package.
  * ----
- * ---- changed: 01Aug2014, 04Aug2014, 28Feb2016, 21Aug2017
+ * ---- changed: 01Aug2014, 04Aug2014, 28Feb2016, 21Aug2017, 29Nov2023
  * ----
  * ----
  */

--- a/inc_ar.h
+++ b/inc_ar.h
@@ -31,9 +31,7 @@
 #ifndef __AR_INC_H__
 #define __AR_INC_H__
 
-
 /* include helper */
-
 
 #include "types.h"
 #include "error.h"
@@ -41,6 +39,7 @@
 #include "pattern.h"
 #include "sound.h"
 #include "kit.h"
-
+#include "settings.h"
+#include "global.h"
 
 #endif /* __AR_INC_H__ */

--- a/settings.c
+++ b/settings.c
@@ -1,0 +1,121 @@
+/* ----
+ * ---- file   : settings.c
+ * ---- author : alisomay
+ * ---- legal  : Distributed under terms of the MIT LICENSE (MIT).
+ * ----
+ * ---- Permission is hereby granted, free of charge, to any person obtaining a copy
+ * ---- of this software and associated documentation files (the "Software"), to deal
+ * ---- in the Software without restriction, including without limitation the rights
+ * ---- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * ---- copies of the Software, and to permit persons to whom the Software is
+ * ---- furnished to do so, subject to the following conditions:
+ * ----
+ * ---- The above copyright notice and this permission notice shall be included in
+ * ---- all copies or substantial portions of the Software.
+ * ----
+ * ---- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * ---- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * ---- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * ---- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * ---- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * ---- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * ---- THE SOFTWARE.
+ * ----
+ * ---- info   : This is part of the "libanalogrytm" package.
+ * ----
+ * ---- created: 28Nov2023
+ * ---- changed: N/A
+ * ----
+ * ----
+ */
+
+// #define AR_DEBUG defined
+
+#include "types.h"
+#include "debug.h"
+#include "error.h"
+#include "sysex.h"
+#include "settings.h"
+
+/* ---------------------------------------------------------------------------- ar_settings_request */
+ar_error_t ar_settings_request(sU8 *_dstBuf, sU8 _devId)
+{
+    ar_sysex_meta_t meta;
+    ar_error_t ret;
+
+    /* For the settings type object number is ignored. */
+    /* Settings are global across device. */
+    AR_SYSEX_META_INIT(meta, _devId, AR_TYPE_SETTINGS, 0x00u);
+
+    ret = ar_sysex_request(_dstBuf, &meta);
+
+    return ret;
+}
+
+/* ---------------------------------------------------------------------------- ar_settings_syx_to_raw */
+ar_error_t ar_settings_syx_to_raw(sU8 *_rawBuf,
+                                  const sU8 *_syxBuf,
+                                  sU32 _syxBufSize,
+                                  sU32 *_retRawBufSize,
+                                  ar_sysex_meta_t *_meta)
+{
+    ar_error_t ret;
+    sU32 datSz;
+    ar_sysex_meta_t meta;
+
+    ret = ar_sysex_to_raw(_rawBuf, &_syxBuf, &_syxBufSize, &datSz, &meta);
+
+    Dprintf("xxx ar_settings_syx_to_raw: syxSz=%u rawSz=%u  sizeof(settings)=%lu\n", _syxBufSize, datSz, sizeof(ar_settings_t));
+
+    if (AR_ERR_OK == ret)
+    {
+        if (NULL != _retRawBufSize)
+        {
+            *_retRawBufSize = datSz;
+        }
+
+        if (NULL != _meta)
+        {
+            *_meta = meta;
+        }
+
+        if (AR_TYPE_SETTINGS == meta.obj_type)
+        {
+            /* Succeeded */
+        }
+        else
+        {
+            ret = AR_ERR_NOT_A_SETTINGS;
+        }
+    }
+
+    return ret;
+}
+
+/* ---------------------------------------------------------------------------- ar_settings_raw_to_syx */
+ar_error_t ar_settings_raw_to_syx(sU8 *_syxBuf,
+                                  const sU8 *_rawBuf,
+                                  sU32 _rawBufSize,
+                                  sU32 *_retSyxBufSize,
+                                  const ar_sysex_meta_t *_meta)
+{
+    ar_error_t ret;
+
+    if (NULL != _meta)
+    {
+        sU32 syxSz;
+
+        ret = ar_raw_to_sysex(_syxBuf, _rawBuf, _rawBufSize, &syxSz, _meta);
+
+        if (NULL != _retSyxBufSize)
+        {
+            *_retSyxBufSize = syxSz;
+        }
+    }
+    else
+    {
+        ret = AR_ERR_NULLPTR;
+    }
+
+    return ret;
+}

--- a/settings.h
+++ b/settings.h
@@ -1,0 +1,150 @@
+/* ----
+ * ---- file   : settings.h
+ * ---- author : alisomay
+ * ---- legal  : Distributed under terms of the MIT LICENSE (MIT).
+ * ----
+ * ---- Permission is hereby granted, free of charge, to any person obtaining a copy
+ * ---- of this software and associated documentation files (the "Software"), to deal
+ * ---- in the Software without restriction, including without limitation the rights
+ * ---- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * ---- copies of the Software, and to permit persons to whom the Software is
+ * ---- furnished to do so, subject to the following conditions:
+ * ----
+ * ---- The above copyright notice and this permission notice shall be included in
+ * ---- all copies or substantial portions of the Software.
+ * ----
+ * ---- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * ---- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * ---- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * ---- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * ---- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * ---- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * ---- THE SOFTWARE. * ----
+ * ---- info   : This is part of the "libanalogrytm" package.
+ * ----
+ * ---- created: 29Nov2023
+ * ---- changed: N/A
+ * ----
+ * ----
+ */
+
+#ifndef __AR_SETTINGS_H__
+#define __AR_SETTINGS_H__
+
+#include "cplusplus_begin.h"
+
+#pragma pack(push)
+#pragma pack(1)
+
+/*
+ *
+ ** Settings structure
+ *
+ *    0x0827(2087) bytes (v5/FW1.70)
+ *
+ */
+typedef struct
+{
+    sU8 version[4]; /* @0x0000..0x0003  32 bit version number (0x00, 0x00, 0x00, 0x03) */
+
+    sU8 bpm_msb;                         /* @0x0004 multiplied by 120. (used when BPM mode=PRJ)          */
+    sU8 bpm_lsb;                         /* @0x0005                                                     */
+    sU8 selected_track;                  /* @0x0006 range=0..11 */
+    sU8 _selected_track_duplicate;       /* @0x0007 duplicate of the selected_track, I don't know why it exists. */
+    sU8 selected_trig_or_parameter_menu; /* @0x0008 range=0..5, 0=TRIG, 1=SRC, 2=SMPL, 3=FLTR, 4=AMP, 5=LFO */
+    sU8 selected_fx_menu;                /* @0x0009 range=0..5, 0=TODO, 1=Delay, 2=Reverb, 3=Dist, 4=Comp, 5=LFO */
+    sU8 selected_page;                   /* @0x000A range=0..3, 0=Page 1, 1=Page 2, 2=Page 3, 3=Page 4, only when manually selected. */
+
+    sU8 __unknown_0x0B; /* @?0x000B Reads 0x00 */
+
+    sU8 track_mute_msb; /* @?0x000C (semantics not decoded yet) */
+    sU8 track_mute_lsb; /* @?0x000D (semantics not decoded yet) */
+
+    sU8 __unknown0x000E_0x0014[7]; /* @?0x000E..0x0014 All zeros. */
+
+    sU8 selected_mode; /* @0x0015 range=0..2, 0=NORMAL, 1=CHAIN, 2=SONG */
+    /* I'd expect 0..3 for the range of this parameter but it stops at 2. It might be a bug in elektron. */
+    sU8 selected_pattern_transition_mode; /* @0x0016 range=0..2, 0=Sequential, 1=Direct Start, 2=Direct Jump or Temp Jump */
+
+    sU8 __unknown0x0017_0x0019[3]; /* @?0x0017..0x0019 All zeros. */
+
+    sU8 fixed_velocity_enable; /* @0x001A 0=OFF, 1=ON */
+    sU8 fixed_velocity_amount; /* @0x001B range=0..127 */
+
+    sU8 sample_recorder_src;     /* @0x001C range=0..14, 0=AUD L+R, 1=AUD L, 2=AUD R, 3=BD, 4=SD, 5=RS/CP, 6=BT, 7=LT, */
+                                 /* 8=MT/HT, 9=CH/OH, 10=CY/CB, 11=MAIN, 12=USB L, 13=USB R, 14=USB L+R,  */
+    sU8 sample_recorder_thr;     /* @0x001D range=0..127  Threshold */
+    sU8 sample_recorder_monitor; /* @0x001E range=0..1, 0=OFF, 1=ON */
+
+    /* The response continues with the repeating 16 byte pattern of 0xFF_FF_FF_FF 0x00_00_00_00 0x00_00_00_00 0x00_00_00_00 */
+    /* The repeating pattern repeats 128 times. Total length of 2048 bytes. */
+    sU8 __repeating_pattern0x001F_0x081E[16 * 128]; /* @?0x001F..0x081E */
+
+    sU8 __unknown0x081F[2]; /* @?0x081F Always 0x01 */
+
+    sU8 sample_recorder_rlen; /* @0x0820 range=0..8  Recording length */
+
+    sU8 __unknown0x0821_0x0826[6]; /* @?0x0821..0x0826  All zeros. */
+
+} ar_settings_t;
+
+/*
+ * Create settings sysex request.
+ *
+ *  Arguments:
+ *     _dstbuf - Destination buffer. Must be large enough to hold the request string (15 bytes, see AR_SYSEX_REQUEST_MSG_SZ).
+ *      _devId - Sysex device id (0..15).
+ *
+ *  Returns:
+ *   AR_ERR_OK if the request was created successfully.
+ *
+ */
+S_EXTERN ar_error_t ar_settings_request(sU8 *_dstBuf, sU8 _devId);
+
+/*
+ * Convert settings sysex dump (starting with 0xF0) to 'raw' 8bit data.
+ *
+ *  Arguments:
+ *          _rawBuf - Destination buffer. Must be large enough to hold the decoded 'raw' 8bit data.
+ *                     Pass NULL to query the required buffer size.
+ *          _syxBuf - Source buffer that stores the encoded 7bit MIDI data (starting with 0xF0)
+ *      _syxBufSize - Size of the source buffer (number of bytes)
+ *   _retRawBufSize - If not NULL, returns the required size of the 'raw' 8bit data buffer.
+ *         _retMeta - If not NULL, returns additional meta data like version.
+ *
+ *  Returns:
+ *   AR_ERR_OK if the request was created successfully.
+ *
+ */
+S_EXTERN ar_error_t ar_settings_syx_to_raw(sU8 *_rawBuf,
+                                           const sU8 *_syxBuf,
+                                           sU32 _syxBufSize,
+                                           sU32 *_retRawBufSize,
+                                           ar_sysex_meta_t *_meta);
+
+/*
+ * Convert 'raw' 8bit data to 7bit MIDI sysex data (starting with 0xF0).
+ *
+ *  Arguments:
+ *          _syxBuf - Destination buffer. Must be large enough to hold the encoded 7bit MIDI sysex data.
+ *                     Pass NULL to query the required buffer size.
+ *          _rawBuf - Source buffer that stores the 'raw' 8bit data.
+ *      _rawBufSize - Size of source buffer (number of bytes).
+ *   _retSyxBufSize - If not NULL, returns the required size of the 7bit MIDI sysex data buffer.
+ *            _meta - Determines format version(s). Must not be NULL.
+ *
+ *  Returns:
+ *   AR_ERR_OK if the request was created successfully.
+ *
+ */
+S_EXTERN ar_error_t ar_settings_raw_to_syx(sU8 *_syxBuf,
+                                           const sU8 *_rawBuf,
+                                           sU32 _rawBufSize,
+                                           sU32 *_retSyxBufSize,
+                                           const ar_sysex_meta_t *_meta);
+
+#pragma pack(pop)
+
+#include "cplusplus_end.h"
+
+#endif /* __AR_SETTINGS_H__ */

--- a/settings.h
+++ b/settings.h
@@ -55,7 +55,7 @@ typedef struct
     sU8 selected_fx_menu;                /* @0x0009 range=0..5, 0=TODO, 1=Delay, 2=Reverb, 3=Dist, 4=Comp, 5=LFO */
     sU8 selected_page;                   /* @0x000A range=0..3, 0=Page 1, 1=Page 2, 2=Page 3, 3=Page 4, only when manually selected. */
 
-    sU8 __unknown_0x0B; /* @?0x000B Reads 0x00 */
+    sU8 __unknown_0x000B; /* @?0x000B Reads 0x00 */
 
     sU8 track_mute_msb; /* @?0x000C (semantics not decoded yet) */
     sU8 track_mute_lsb; /* @?0x000D (semantics not decoded yet) */
@@ -80,7 +80,7 @@ typedef struct
     /* The repeating pattern repeats 128 times. Total length of 2048 bytes. */
     sU8 __repeating_pattern0x001F_0x081E[16 * 128]; /* @?0x001F..0x081E */
 
-    sU8 __unknown0x081F[2]; /* @?0x081F Always 0x01 */
+    sU8 __unknown0x081F; /* @?0x081F Always 0x01 */
 
     sU8 sample_recorder_rlen; /* @0x0820 range=0..8  Recording length */
 


### PR DESCRIPTION
## Intro

This PR adds 

- The reversed packed struct type `ar_settings_t` for  `AR_TYPE_SETTINGS`.
- Adds a simple CI workflow which runs `make` on pushes. 
- Updates `README.md` to show a CI badge. 

## Details

- All reverse engineered fields are tested multiple times. 
- Maybe quickly going through the preferred formater might be necessary. (If you have any rules for your formater or you use a specific IDE I'd love to know so I don't cause extra labour like this 🙏 )
- As usual please feel free to change the proposed code as you wish. ✨ 

Thank you for the review 🙏 